### PR TITLE
Update README.md | Revert "name" & "group" tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It's a unique object which contains:
 
 ##### The Anime object
 An anime object contains:
-* *`name`*: **required**; it's the ```html<td>```` of the table, appears in the colum of `name`
+* *`name`*: **required**; it's the `<td>` of the table, appears in the colum of `name`
 * *`image`* from MyAnimeList link (or livechart exceptionally); **required**; show it when click on the button
 * *`group`* (array) of subs-group which subs it: **required**. An object `group` can have:
 	* a *`status`* (uncertain, planned, release, dropped, simulcast): **required** if `detail` exists (see below);

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This site has the goal to list all the new airing/streaming anime in Japan, and 
 It's not really an API.
 Our website hosts `JSON` files to load our `HTML` files content.
 <br><br>
-You can access to it over **GET** on **HTTP** or **HTTPS** on fansubdb.github.io/`:lang/:years/:season.json`
+You can access to it over **GET** on **HTTP** or **HTTPS** on FansubDB.Github.io/`:lang/:years/:season.json`
 <br>
-* `:lang` can be found on `fansubdb.github.io/lang.json`
-* `:year` and `:season` can be found on `fansubdb.github.io/:lang/list.json` (`:lang` come from above)
+* `:lang` can be found on `FansubDB.Github.io/lang.json`
+* `:year` and `:season` can be found on `FansubDB.Github.io/:lang/list.json` (`:lang` come from above)
 
 ## I want to help you.
 No problem, do a pull request :)
@@ -27,17 +27,17 @@ They have an objects table. The object contains each value (lang/year/season) an
 This file is located under `:lang/:year/:season.json`. (eg. [`fr/2014/automne.json`](fr/2014/automne.json))
 
 It's a unique object which contains: 
-* *`lbl_tv`*: The label of the button to show `tv` list; **required**
-* *`lbl_ova`*: The label of the button to show `ova/ona/special` list; **required**
-* *`lbl_movie`*: The label of the button to show `movie` list; **required**
-* *`message`*: Show the text when the array `tv`, `ova` or `movie` is empty (i.e. contains 0 value)
-* *`tv`*: an array of `anime` objects; **required**.
-* *`ova`*: an array of `anime` objects; **required**.
-* *`movie`*: an array of `anime` objects; **required**.
+* *`lbl_tv`*: The label of the button to show `TV` list; **required**
+* *`lbl_ova`*: The label of the button to show `OAV/ONA/Special` list; **required**
+* *`lbl_movie`*: The label of the button to show `Movie` list; **required**
+* *`message`*: Show the text when the array `tv`,`ova` or `movie` is empty (i.e. contains 0 value)
+* *`tv`*: an array of anime objects; **required**.
+* *`ova`*: an array of anime objects; **required**.
+* *`movie`*: an array of anime objects; **required**.
 
-##### The `Anime` object
-An `anime` object contains:
-* *`name`*: **required**; it's the `<td>` of the table, appears in the colum of `name`
+##### The Anime object
+An anime object contains:
+* *`name`*: **required**; it's the ```html<td>```` of the table, appears in the colum of `name`
 * *`image`* from MyAnimeList link (or livechart exceptionally); **required**; show it when click on the button
 * *`group`* (array) of subs-group which subs it: **required**. An object `group` can have:
 	* a *`status`* (uncertain, planned, release, dropped, simulcast): **required** if `detail` exists (see below);
@@ -49,8 +49,8 @@ An `anime` object contains:
 ```json
 {
 	"lbl_tv": "TV",
-	"lbl_ova": "OAV/ONA/Spéciaux",
-	"lbl_movie": "Films",
+	"lbl_ova": "OAV/ONA/Special",
+	"lbl_movie": "Movie",
 	"message": "This list is empty! <br>Don't hesitate to submit a PR.",
 	"tv": [{
 		"name": "Anime A",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [FansubDB.github.io](https://fansubdb.github.io/)
+# [FansubDB.Github.io](https://fansubdb.github.io/)
 
 ## What is it?
 This site has the goal to list all the new airing/streaming anime in Japan, and which subs groups are subbing (or plan to sub) them.
@@ -7,9 +7,9 @@ This site has the goal to list all the new airing/streaming anime in Japan, and 
 It's not really an API.
 Our website hosts `JSON` files to load our `HTML` files content.
 <br><br>
-You can access to it over **GET** on **HTTP** or **HTTPS** on fansub.github.io/`:lang/:years/:season.json`
+You can access to it over **GET** on **HTTP** or **HTTPS** on fansubdb.github.io/`:lang/:years/:season.json`
 <br>
-* `:lang` can be found on `fansub.github.io/lang.json`
+* `:lang` can be found on `fansubdb.github.io/lang.json`
 * `:year` and `:season` can be found on `fansubdb.github.io/:lang/list.json` (`:lang` come from above)
 
 ## I want to help you.
@@ -24,11 +24,9 @@ No problem, do a pull request :)
 They have an objects table. The object contains each value (lang/year/season) and their url.
 
 #### The json file of the season animes
-This file is located under `:lang/:year/:season.json`. (eg. [`fr/2014/automne_TV.json`](fr/2014/automne_TV.json))
+This file is located under `:lang/:year/:season.json`. (eg. [`fr/2014/automne.json`](fr/2014/automne.json))
 
 It's a unique object which contains: 
-* *name*: Translation of the name; **required**; it's the `<th>` of the table
-* *group*: Translation of the group; **required**; it's the second `<th>` of the table
 * *lbl_tv*: The label of the button to show `tv` list; **required**
 * *lbl_ova*: The label of the button to show `ova/ona/special` list; **required**
 * *lbl_movie*: The label of the button to show `movie` list; **required**
@@ -48,10 +46,8 @@ An `anime` object contains:
 		* and its *url* (see [External Links](#external-links)): **optional**
 
 ##### Simple example of a JSON file
-```
+```json
 {
-	"name": "name",
-	"group": "fansub group",
 	"lbl_tv": "TV",
 	"lbl_ova": "OAV/ONA/Spéciaux",
 	"lbl_movie": "Films",

--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ They have an objects table. The object contains each value (lang/year/season) an
 This file is located under `:lang/:year/:season.json`. (eg. [`fr/2014/automne.json`](fr/2014/automne.json))
 
 It's a unique object which contains: 
-* *lbl_tv*: The label of the button to show `tv` list; **required**
-* *lbl_ova*: The label of the button to show `ova/ona/special` list; **required**
-* *lbl_movie*: The label of the button to show `movie` list; **required**
-* *message*: Show the text when the array `tv`, `ova` or `movie` is empty (i.e. contains 0 value)
-* *tv*: an array of `anime` objects; **required**.
-* *ova*: an array of `anime` objects; **required**.
-* *movie*: an array of `anime` objects; **required**.
+* *`lbl_tv`*: The label of the button to show `tv` list; **required**
+* *`lbl_ova`*: The label of the button to show `ova/ona/special` list; **required**
+* *`lbl_movie`*: The label of the button to show `movie` list; **required**
+* *`message`*: Show the text when the array `tv`, `ova` or `movie` is empty (i.e. contains 0 value)
+* *`tv`*: an array of `anime` objects; **required**.
+* *`ova`*: an array of `anime` objects; **required**.
+* *`movie`*: an array of `anime` objects; **required**.
 
 ##### The `Anime` object
 An `anime` object contains:
-* *name*: **required**; it's the `<td>` of the table, appears in the colum of `name`
-* *image* from MyAnimeList link (or livechart exceptionally); **required**; show it when click on the button
-* *group* (array) of subs-group which subs it: **required**. An object `group` can have:
-	* a *status* (uncertain, planned, release, dropped, simulcast): **required** if `detail` exists (see below);
-	* an array named *detail*, where we have the possibility to add co-subbing: **required** if `status` exists. This array contains:
-		* the *name* of the group: **required** if `status` exists
-		* and its *url* (see [External Links](#external-links)): **optional**
+* *`name`*: **required**; it's the `<td>` of the table, appears in the colum of `name`
+* *`image`* from MyAnimeList link (or livechart exceptionally); **required**; show it when click on the button
+* *`group`* (array) of subs-group which subs it: **required**. An object `group` can have:
+	* a *`status`* (uncertain, planned, release, dropped, simulcast): **required** if `detail` exists (see below);
+	* an array named *`detail`*, where we have the possibility to add co-subbing: **required** if `status` exists. This array contains:
+		* the *`name`* of the group: **required** if `status` exists
+		* and its *`url`* (see [External Links](#external-links)): **optional**
 
 ##### Simple example of a JSON file
 ```json

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ They have an objects table. The object contains each value (lang/year/season) an
 This file is located under `:lang/:year/:season.json`. (eg. [`fr/2014/automne.json`](fr/2014/automne.json))
 
 It's a unique object which contains: 
+* *`name`*: Translation of the name; **required**; it's the `<th>` of the table
+* *`group`*: Translation of the group; **required**; it's the second `<th>` of the table
 * *`lbl_tv`*: The label of the button to show `TV` list; **required**
 * *`lbl_ova`*: The label of the button to show `OAV/ONA/Special` list; **required**
 * *`lbl_movie`*: The label of the button to show `Movie` list; **required**
@@ -48,6 +50,8 @@ An anime object contains:
 ##### Simple example of a JSON file
 ```json
 {
+	"name": "name",
+	"group": "fansub group",
 	"lbl_tv": "TV",
 	"lbl_ova": "OAV/ONA/Special",
 	"lbl_movie": "Movie",


### PR DESCRIPTION
Rename "fansub.github.io" by "fansubdb.github.io"
Rename "github" by "Github"
Rename "automne_TV.json" by "automne.json"

Remove the "name" & "group" tags in the Json code (Don't know why they are here, they are already in the "tv" tag, so WHY?)

Add "json" in the exemple of code for display Json's code color

Edit:
Add "`" for displaying that they are Json's "tags"

Edit2:
Live Preview : https://github.com/KasaiDot/fansub.github.io/tree/patch-2